### PR TITLE
RET-1852: ET1 serving- Who are you sending this document to

### DIFF
--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/Et1CaseData.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/Et1CaseData.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.et.common.model.ccd;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
+import uk.gov.hmcts.et.common.model.ccd.items.DocumentTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.types.*;
 import uk.gov.hmcts.et.common.model.ccd.items.JurCodesTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.items.RespondentSumTypeItem;
@@ -44,4 +45,9 @@ public class Et1CaseData {
     private ClaimantRequestType claimantRequests;
     @JsonProperty("claimantHearingPreference")
     private ClaimantHearingPreference claimantHearingPreference;
+    @JsonProperty("servingDocumentCollection")
+    private List<DocumentTypeItem> servingDocumentCollection;
+    @JsonProperty("otherTypeDocumentName")
+    private String otherTypeDocumentName;
+
 }


### PR DESCRIPTION
(https://tools.hmcts.net/jira/browse/RET-1852)


### Change description ###
Following the submission of the ET1 form by the Claimant, the ET1 is vetted, and if accepted then the ET1 is required to be served to the Respondent (as per the Respondent details in the ET1 form).  A notification letter of ET1 serving is sent to the Respondent, together with a copy of ET3 form (by post) ** 

NB: This page will only come up if on the Upload letters page dropdown, the user selects another type of document which is not a known standard letter. Once the document has been uploaded, the admin/caseworker will need to select who the document will be sent to.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
