### PR TITLE
Ret 1853

### DIFF
--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/Address.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/Address.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.et.common.model.ccd;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Strings;
 import lombok.Data;
 
 import java.util.ArrayList;
@@ -32,6 +33,22 @@ public class Address {
     public String toString() {
         return String.join(", ", notNullOrEmptyAddress(new ArrayList<>(), Arrays.asList(addressLine1,
                 addressLine2, addressLine3, postTown, county, postCode, country)));
+    }
+
+    public String toAddressString() {
+        StringBuilder claimantAddressStr = new StringBuilder();
+        claimantAddressStr.append("<br/>" + addressLine1);
+        if (!Strings.isNullOrEmpty(addressLine2)) {
+            claimantAddressStr.append("<br/>" + addressLine2);
+        }
+        if(!Strings.isNullOrEmpty(addressLine3)) {
+            claimantAddressStr.append("<br/>" + addressLine3);
+        }
+        claimantAddressStr.append("<br/>" + postTown)
+                .append("<br/>" + postCode)
+                .append("<br/><br/>");
+
+        return claimantAddressStr.toString();
     }
 
     private List<String> notNullOrEmptyAddress(List<String> fullAddress, List<String> attributes) {

--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/Et1CaseData.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/Et1CaseData.java
@@ -49,8 +49,8 @@ public class Et1CaseData {
     private List<DocumentTypeItem> servingDocumentCollection;
     @JsonProperty("otherTypeDocumentName")
     private String otherTypeDocumentName;
-    @JsonProperty("claimantAddress")
-    private String claimantAddress;
-    @JsonProperty("respondentAddress")
-    private String respondentAddress;
+    @JsonProperty("servingDocumentRecipient")
+    private List<String> servingDocumentRecipient;
+    @JsonProperty("claimantAndRespondentAddresses")
+    private String claimantAndRespondentAddresses;
 }

--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/Et1CaseData.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/Et1CaseData.java
@@ -49,5 +49,6 @@ public class Et1CaseData {
     private List<DocumentTypeItem> servingDocumentCollection;
     @JsonProperty("otherTypeDocumentName")
     private String otherTypeDocumentName;
-
+    @JsonProperty("claimantAndRespondentAddresses")
+    private String claimantAndRespondentAddresses;
 }

--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/Et1CaseData.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/Et1CaseData.java
@@ -49,6 +49,8 @@ public class Et1CaseData {
     private List<DocumentTypeItem> servingDocumentCollection;
     @JsonProperty("otherTypeDocumentName")
     private String otherTypeDocumentName;
-    @JsonProperty("claimantAndRespondentAddresses")
-    private String claimantAndRespondentAddresses;
+    @JsonProperty("claimantAddress")
+    private String claimantAddress;
+    @JsonProperty("respondentAddress")
+    private String respondentAddress;
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RET-1853



### Change description ###
Following the submission of the ET1 form by the Claimant, the ET1 is vetted, and if accepted then the ET1 is required to be served to the Respondent (as per the Respondent details in the ET1 form).  A notification letter of ET1 serving is sent to the Respondent, together with a copy of ET3 form (by post) ** 

The relevant documents uploaded into the casefile will need to be sent to the parties involved, the admin/caseworker should be able to verify that the documents are sent to the right parties. This page will help in verifying that the details are accurate. Once the details have been verified, the documents will be printed and sent manually.

NB: The respondent will always receive paper at this stage, the claimant details will only be included here if the claimant has asked for paper instead of being notified via GOV.Notify.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
