### PR TITLE
Reorganise case data properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '1.0.12'
+version '1.0.13'
 
 sourceCompatibility = '11.0'
 

--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/CaseData.java
@@ -24,6 +24,9 @@ import uk.gov.hmcts.et.common.model.listing.ListingData;
 
 import java.util.List;
 
+/**
+ * Employment Tribunal claim data. This class contains all the data for a citizen's claim.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -320,4 +323,20 @@ public class CaseData extends Et1CaseData {
     private String hearingDetailsTimingDuration;
     @JsonProperty("hearingDetailsHearingNotes2")
     private String hearingDetailsHearingNotes2;
+
+    // ET1 Vetting
+    @JsonProperty("vettingBeforeLink")
+    private String vettingBeforeLink;
+
+    // ET1 Serving
+    @JsonProperty("servingDocumentCollection")
+    private List<DocumentTypeItem> servingDocumentCollection;
+    @JsonProperty("otherTypeDocumentName")
+    private String otherTypeDocumentName;
+    @JsonProperty("servingDocumentRecipient")
+    private List<String> servingDocumentRecipient;
+    @JsonProperty("claimantAndRespondentAddresses")
+    private String claimantAndRespondentAddresses;
+    @JsonProperty("emailLinkToAcas")
+    private String emailLinkToAcas;
 }

--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/CaseData.java
@@ -325,8 +325,8 @@ public class CaseData extends Et1CaseData {
     private String hearingDetailsHearingNotes2;
 
     // ET1 Vetting
-    @JsonProperty("vettingBeforeLink")
-    private String vettingBeforeLink;
+    @JsonProperty("et1VettingBeforeYouStart")
+    private String et1VettingBeforeYouStart;
 
     // ET1 Serving
     @JsonProperty("servingDocumentCollection")

--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/Et1CaseData.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/Et1CaseData.java
@@ -3,13 +3,17 @@ package uk.gov.hmcts.et.common.model.ccd;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
-import uk.gov.hmcts.et.common.model.ccd.items.DocumentTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.types.*;
 import uk.gov.hmcts.et.common.model.ccd.items.JurCodesTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.items.RespondentSumTypeItem;
 
 import java.util.List;
 
+/**
+ * Employment Tribunal claim data that is input on the ET1 form by a claimant.
+ *
+ * This class should only contain data that is specifically part of the ET1 form.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
 public class Et1CaseData {
@@ -47,18 +51,6 @@ public class Et1CaseData {
     private ClaimantRequestType claimantRequests;
     @JsonProperty("claimantHearingPreference")
     private ClaimantHearingPreference claimantHearingPreference;
-    @JsonProperty("servingDocumentCollection")
-    private List<DocumentTypeItem> servingDocumentCollection;
-    @JsonProperty("otherTypeDocumentName")
-    private String otherTypeDocumentName;
-    @JsonProperty("servingDocumentRecipient")
-    private List<String> servingDocumentRecipient;
-    @JsonProperty("claimantAndRespondentAddresses")
-    private String claimantAndRespondentAddresses;
-    @JsonProperty("emailLinkToAcas")
-    private String emailLinkToAcas;
     @JsonProperty("claimantTaskListChecks")
     private TaskListCheckType claimantTaskListChecks;
-    @JsonProperty("vettingBeforeLink")
-    private String vettingBeforeLink;
 }


### PR DESCRIPTION
### Change description ###
Reorganise case data properties so that Et1CaseData.java only contains data populated from the ET1 form. This is so that et-sya-api/frontend are not exposed to CCD data that it does not populate


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
