### PR TITLE
added ET3 response fields for 1863, 1930 and 1872

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '1.0.36'
+version '1.0.38'
 
 sourceCompatibility = '11.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '1.0.38'
+version '1.0.37'
 
 sourceCompatibility = '11.0'
 

--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/CaseData.java
@@ -574,4 +574,28 @@ public class CaseData extends Et1CaseData {
     private EtInitialConsiderationRule27 etInitialConsiderationRule27;
     @JsonProperty("etInitialConsiderationRule28")
     private EtInitialConsiderationRule28 etInitialConsiderationRule28;
+
+    // ET3 Response
+    @JsonProperty("et3ResponseShowInset")
+    private String et3ResponseShowInset;
+    // ET3 Response - Claimaint name page
+    @JsonProperty("et3ResponseClaimantName")
+    private String et3ResponseClaimantName;
+    @JsonProperty("et3ResponseIsClaimantNameCorrect")
+    private String et3ResponseIsClaimantNameCorrect;
+    @JsonProperty("et3ResponseClaimantNameCorrection")
+    private String et3ResponseClaimantNameCorrection;
+    // ET3 Response - What is the respondent's name
+    @JsonProperty("et3ResponseNameShowInset")
+    private String et3ResponseNameShowInset;
+    @JsonProperty("et3ResponseRespondentLegalName")
+    private String et3ResponseRespondentLegalName;
+    @JsonProperty("et3ResponseRespondentCompanyNumber")
+    private String et3ResponseRespondentCompanyNumber;
+    @JsonProperty("et3ResponseRespondentEmployerType")
+    private String et3ResponseRespondentEmployerType;
+    @JsonProperty("et3ResponseRespondentPreferredTitle")
+    private String et3ResponseRespondentPreferredTitle;
+    @JsonProperty("et3ResponseRespondentContactName")
+    private String et3ResponseRespondentContactName;
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-1930
https://tools.hmcts.net/jira/browse/RET-1863
https://tools.hmcts.net/jira/browse/RET-1872

### Change description ###

added ET3 response fields for 1863, 1930 and 1872

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
