### PR TITLE
reverting adding et3ResponseDocument

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '1.0.61'
+version '1.0.62'
 
 sourceCompatibility = '11.0'
 

--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/CaseData.java
@@ -857,8 +857,6 @@ public class CaseData extends Et1CaseData {
     private String et3ResponseRespondentSupportDetails;
     @JsonProperty("et3ResponseRespondentSupportDocument")
     private UploadedDocumentType et3ResponseRespondentSupportDocument;
-    @JsonProperty("et3ResponseDocument")
-    private UploadedDocumentType et3ResponseDocument;
 
     // ET3 Notification
     @JsonProperty("et3NotificationDocCollection")


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-2411

### Change description ###

Removed et3ResponseDocument field as we're storing et3 response documents in documentCollection now

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
