### PR TITLE
2639: add empty constructors to referralTypeR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '1.0.74-2639'
+version '1.0.76'
 
 sourceCompatibility = '11.0'
 

--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/types/RepresentedTypeR.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/types/RepresentedTypeR.java
@@ -2,14 +2,18 @@ package uk.gov.hmcts.et.common.model.ccd.types;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import uk.gov.hmcts.et.common.model.bulk.types.DynamicFixedListType;
 import uk.gov.hmcts.et.common.model.ccd.Address;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class RepresentedTypeR {
 
     @JsonProperty("dynamic_resp_rep_name")


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-2639


### Change description ###
add empty constructors to referralTypeR


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
