### PR TITLE
RET-3085: Added submitted page for respondent bundles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.github.hmcts'
-version '2.0.1'
+version '2.1.0'
 
 sourceCompatibility = '11.0'
 

--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/CaseData.java
@@ -27,6 +27,7 @@ import uk.gov.hmcts.et.common.model.ccd.types.CompanyPremisesType;
 import uk.gov.hmcts.et.common.model.ccd.types.CorrespondenceScotType;
 import uk.gov.hmcts.et.common.model.ccd.types.CorrespondenceType;
 import uk.gov.hmcts.et.common.model.ccd.types.DocumentType;
+import uk.gov.hmcts.et.common.model.ccd.types.HearingBundleType;
 import uk.gov.hmcts.et.common.model.ccd.types.NoticeOfChangeAnswers;
 import uk.gov.hmcts.et.common.model.ccd.types.OrganisationPolicy;
 import uk.gov.hmcts.et.common.model.ccd.types.RestrictedReportingType;
@@ -1268,6 +1269,14 @@ public class CaseData extends Et1CaseData {
     @JsonProperty("bundlesRespondentSelectHearing")
     private DynamicFixedListType bundlesRespondentSelectHearing;
 
+    @JsonProperty("bundlesRespondentWhatDocuments")
+    private String bundlesRespondentWhatDocuments;
+
+    @JsonProperty("bundlesRespondentWhoseDocuments")
+    private String bundlesRespondentWhoseDocuments;
+
     @JsonProperty("bundlesRespondentUploadFile")
     private UploadedDocumentType bundlesRespondentUploadFile;
+    @JsonProperty("bundlesRespondentCollection")
+    private List<GenericTypeItem<HearingBundleType>> bundlesRespondentCollection;
 }

--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/types/HearingBundleType.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/types/HearingBundleType.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.et.common.model.ccd.types;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+@SuperBuilder
+@NoArgsConstructor
+public class HearingBundleType {
+    @JsonProperty("agreedDocWith")
+    private String agreedDocWith;
+    @JsonProperty("agreedDocWithBut")
+    private String agreedDocWithBut;
+    @JsonProperty("agreedDocWithNo")
+    private String agreedDocWithNo;
+    @JsonProperty("hearing")
+    private String hearing;
+    @JsonProperty("whatDocuments")
+    private String whatDocuments;
+    @JsonProperty("whoseDocuments")
+    private String whoseDocuments;
+    @JsonProperty("uploadFile")
+    private UploadedDocumentType uploadFile;
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-3085

### Change description ###

Added submitted page for respondent bundles

**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[x] No
```
