### PR TITLE
RET-3592: Removed several tabs for caseworker-employment and caseworker-employment-legalrep-solicitor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.github.hmcts'
-version '2.1.0'
+version '2.1.1'
 
 sourceCompatibility = '11.0'
 

--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/CaseData.java
@@ -1282,4 +1282,6 @@ public class CaseData extends Et1CaseData {
     private UploadedDocumentType bundlesRespondentUploadFile;
     @JsonProperty("bundlesRespondentCollection")
     private List<GenericTypeItem<HearingBundleType>> bundlesRespondentCollection;
+    @JsonProperty("legalrepDocumentCollection")
+    private List<DocumentTypeItem> legalrepDocumentCollection;
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-3592

### Change description ###

Removed several tabs for caseworker-employment and caseworker-employment-legalrep-solicitor

**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[x] No
```
