### PR TITLE
RET-0000: bump to 2.3.5 for JitPack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.github.hmcts'
-version '2.3.4'
+version '2.3.5'
 
 java {
     toolchain {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-0000

### Change description ###

bump to 2.3.5 for JitPack

**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[x] No
```
