### PR TITLE
RET-3514 Removing control for Non System Users on Respond To An Application process

### DIFF
--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/CaseData.java
@@ -20,23 +20,7 @@ import uk.gov.hmcts.et.common.model.ccd.items.ListTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.items.ReferralTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.items.RepresentedTypeRItem;
 import uk.gov.hmcts.et.common.model.ccd.items.VettingJurCodesTypeItem;
-import uk.gov.hmcts.et.common.model.ccd.types.AddressLabelsAttributesType;
-import uk.gov.hmcts.et.common.model.ccd.types.AddressLabelsSelectionType;
-import uk.gov.hmcts.et.common.model.ccd.types.CaseFlagsType;
-import uk.gov.hmcts.et.common.model.ccd.types.CaseLink;
-import uk.gov.hmcts.et.common.model.ccd.types.CaseLocation;
-import uk.gov.hmcts.et.common.model.ccd.types.CasePreAcceptType;
-import uk.gov.hmcts.et.common.model.ccd.types.ChangeOrganisationRequest;
-import uk.gov.hmcts.et.common.model.ccd.types.CompanyPremisesType;
-import uk.gov.hmcts.et.common.model.ccd.types.CorrespondenceScotType;
-import uk.gov.hmcts.et.common.model.ccd.types.CorrespondenceType;
-import uk.gov.hmcts.et.common.model.ccd.types.DocumentType;
-import uk.gov.hmcts.et.common.model.ccd.types.HearingBundleType;
-import uk.gov.hmcts.et.common.model.ccd.types.NoticeOfChangeAnswers;
-import uk.gov.hmcts.et.common.model.ccd.types.OrganisationPolicy;
-import uk.gov.hmcts.et.common.model.ccd.types.RestrictedReportingType;
-import uk.gov.hmcts.et.common.model.ccd.types.SendNotificationTypeItem;
-import uk.gov.hmcts.et.common.model.ccd.types.UploadedDocumentType;
+import uk.gov.hmcts.et.common.model.ccd.types.*;
 import uk.gov.hmcts.et.common.model.ccd.types.citizenhub.ClaimantTse;
 import uk.gov.hmcts.et.common.model.hmc.CaseCategory;
 import uk.gov.hmcts.et.common.model.hmc.HearingLocation;
@@ -1108,7 +1092,7 @@ public class CaseData extends Et1CaseData {
     @JsonProperty("resTseTextBox12")
     private String resTseTextBox12;
     @JsonProperty("resTseCopyToOtherPartyYesOrNo")
-    private String resTseCopyToOtherPartyYesOrNo;
+    private DynamicListType resTseCopyToOtherPartyYesOrNo;
     @JsonProperty("resTseCopyToOtherPartyTextArea")
     private String resTseCopyToOtherPartyTextArea;
     @JsonProperty("genericTseApplicationCollection")

--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/CaseData.java
@@ -1437,7 +1437,4 @@ public class CaseData extends Et1CaseData {
 
     @JsonProperty("respondentUnavailability")
     private ListTypeItem<UnavailabilityRanges> respondentUnavailability;
-
-    @JsonProperty("resTseCopyToOtherPartyYesOrNoOptions")
-    private List<String> resTseCopyToOtherPartyYesOrNoOptions;
 }

--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/CaseData.java
@@ -1429,9 +1429,6 @@ public class CaseData extends Et1CaseData {
     @JsonProperty("caseLinks")
     private ListTypeItem<CaseLink> caseLinks;
 
-    @JsonProperty("systemUserYesOrNo")
-    private String systemUserYesOrNo;
-
     @JsonProperty("partySelection")
     private List<String> partySelection;
 
@@ -1440,4 +1437,7 @@ public class CaseData extends Et1CaseData {
 
     @JsonProperty("respondentUnavailability")
     private ListTypeItem<UnavailabilityRanges> respondentUnavailability;
+
+    @JsonProperty("resTseCopyToOtherPartyYesOrNoOptions")
+    private List<String> resTseCopyToOtherPartyYesOrNoOptions;
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-3514

### Change description ###

1. Removed CaseData model field systemUserYesOrNo
2. Updated field resTseCopyToOtherPartyYesOrNo type from String to DynamicListType in CaseData model as

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
