### PR TITLE
Ret 4087 - Populate manual hearings object with values from caseData

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.github.hmcts'
-version '2.6.4'
+version '2.6.7'
 
 java {
     toolchain {

--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/CaseData.java
@@ -163,6 +163,8 @@ public class CaseData extends Et1CaseData {
     private String targetHearingDate;
     @JsonProperty("claimant")
     private String claimant;
+    @JsonProperty("claimantId")
+    private String claimantId;
     @JsonProperty("respondent")
     private String respondent;
 

--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/types/RepresentedTypeC.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/types/RepresentedTypeC.java
@@ -9,6 +9,8 @@ import uk.gov.hmcts.et.common.model.ccd.Address;
 @Data
 public class RepresentedTypeC {
 
+    @JsonProperty("representative_id")
+    private String representativeId;
     @JsonProperty("name_of_representative")
     private String nameOfRepresentative;
     @JsonProperty("name_of_organisation")


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-4087

### Change description ###

Add ID properties for respondent representative and claimant.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
