### PR TITLE
Added BaseCaseData that CaseData and MultipleData extend from

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.github.hmcts'
-version '3.5.0'
+version '3.6.0'
 
 java {
     toolchain {

--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/Et1CaseData.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/Et1CaseData.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.et.common.model.ccd;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import uk.gov.hmcts.et.common.model.ccd.items.JurCodesTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.items.RespondentSumTypeItem;
 import uk.gov.hmcts.et.common.model.ccd.types.AdditionalCaseInfoType;
@@ -17,6 +18,7 @@ import uk.gov.hmcts.et.common.model.ccd.types.RepresentedTypeC;
 import uk.gov.hmcts.et.common.model.ccd.types.TaskListCheckType;
 import uk.gov.hmcts.et.common.model.ccd.types.TriageQuestions;
 import uk.gov.hmcts.et.common.model.ccd.types.citizenhub.HubLinksStatuses;
+import uk.gov.hmcts.et.common.model.generic.BaseCaseData;
 
 import java.util.List;
 
@@ -26,7 +28,8 @@ import java.util.List;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
-public class Et1CaseData {
+@EqualsAndHashCode(callSuper=false)
+public class Et1CaseData extends BaseCaseData {
     @JsonProperty("typeOfClaim")
     private List<String> typeOfClaim;
     @JsonProperty("typesOfClaim")

--- a/src/main/java/uk/gov/hmcts/et/common/model/ccd/Et1CaseData.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/ccd/Et1CaseData.java
@@ -28,7 +28,7 @@ import java.util.List;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
-@EqualsAndHashCode(callSuper=false)
+@EqualsAndHashCode(callSuper = false)
 public class Et1CaseData extends BaseCaseData {
     @JsonProperty("typeOfClaim")
     private List<String> typeOfClaim;

--- a/src/main/java/uk/gov/hmcts/et/common/model/generic/BaseCaseData.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/generic/BaseCaseData.java
@@ -1,0 +1,96 @@
+package uk.gov.hmcts.et.common.model.generic;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import uk.gov.hmcts.et.common.model.bulk.types.DynamicFixedListType;
+import uk.gov.hmcts.et.common.model.ccd.items.DocumentTypeItem;
+import uk.gov.hmcts.et.common.model.ccd.items.ReferralTypeItem;
+
+import java.util.List;
+
+/**
+ * Data common to single and multiple cases.
+ */
+@Getter
+@Setter
+public class BaseCaseData {
+    //Referral
+    @JsonProperty("referralCollection")
+    private List<ReferralTypeItem> referralCollection;
+    @JsonProperty("referralHearingDetails")
+    private String referralHearingDetails;
+    @JsonProperty("selectReferral")
+    private DynamicFixedListType selectReferral;
+    //Referral Type
+    @JsonProperty("referCaseTo")
+    private String referCaseTo;
+    @JsonProperty("referentEmail")
+    private String referentEmail;
+    @JsonProperty("isUrgent")
+    private String isUrgent;
+    @JsonProperty("referralSubject")
+    private String referralSubject;
+    @JsonProperty("referralSubjectSpecify")
+    private String referralSubjectSpecify;
+    @JsonProperty("referralDetails")
+    private String referralDetails;
+    @JsonProperty("referralDocument")
+    private List<DocumentTypeItem> referralDocument;
+    @JsonProperty("referralInstruction")
+    private String referralInstruction;
+    @JsonProperty("referredBy")
+    private String referredBy;
+    @JsonProperty("referralDate")
+    private String referralDate;
+
+    //Referral Update
+    @JsonProperty("updateReferralNumber")
+    private String updateReferralNumber;
+    @JsonProperty("updateReferCaseTo")
+    private String updateReferCaseTo;
+    @JsonProperty("updateReferentEmail")
+    private String updateReferentEmail;
+    @JsonProperty("updateIsUrgent")
+    private String updateIsUrgent;
+    @JsonProperty("updateReferralSubject")
+    private String updateReferralSubject;
+    @JsonProperty("updateReferralSubjectSpecify")
+    private String updateReferralSubjectSpecify;
+    @JsonProperty("updateReferralDetails")
+    private String updateReferralDetails;
+    @JsonProperty("updateReferralDocument")
+    private List<DocumentTypeItem> updateReferralDocument;
+    @JsonProperty("updateReferralInstruction")
+    private String updateReferralInstruction;
+
+    //Referral Reply
+    @JsonProperty("hearingAndReferralDetails")
+    private String hearingAndReferralDetails;
+    @JsonProperty("directionTo")
+    private String directionTo;
+    @JsonProperty("replyToEmailAddress")
+    private String replyToEmailAddress;
+    @JsonProperty("isUrgentReply")
+    private String isUrgentReply;
+    @JsonProperty("directionDetails")
+    private String directionDetails;
+    @JsonProperty("replyDocument")
+    private List<DocumentTypeItem> replyDocument;
+    @JsonProperty("replyGeneralNotes")
+    private String replyGeneralNotes;
+    @JsonProperty("replyTo")
+    private String replyTo;
+    @JsonProperty("replyDetails")
+    private String replyDetails;
+    @JsonProperty("isJudge")
+    private String isJudge;
+
+    //Close Referral
+    @JsonProperty("closeReferralHearingDetails")
+    private String closeReferralHearingDetails;
+    @JsonProperty("confirmCloseReferral")
+    private List<String> confirmCloseReferral;
+    @JsonProperty("closeReferralGeneralNotes")
+    private String closeReferralGeneralNotes;
+}

--- a/src/main/java/uk/gov/hmcts/et/common/model/multiples/MultipleData.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/multiples/MultipleData.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.et.common.model.bulk.items.CaseIdTypeItem;
 import uk.gov.hmcts.et.common.model.bulk.types.DynamicFixedListType;
@@ -16,6 +17,7 @@ import uk.gov.hmcts.et.common.model.ccd.types.CasePreAcceptType;
 import uk.gov.hmcts.et.common.model.ccd.types.CorrespondenceScotType;
 import uk.gov.hmcts.et.common.model.ccd.types.CorrespondenceType;
 import uk.gov.hmcts.et.common.model.ccd.types.SendNotificationTypeItem;
+import uk.gov.hmcts.et.common.model.generic.BaseCaseData;
 import uk.gov.hmcts.et.common.model.multiples.items.CaseMultipleTypeItem;
 import uk.gov.hmcts.et.common.model.multiples.items.SubMultipleTypeItem;
 import uk.gov.hmcts.et.common.model.multiples.types.MoveCasesType;
@@ -28,7 +30,8 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class MultipleData {
+@EqualsAndHashCode(callSuper=false)
+public class MultipleData extends BaseCaseData {
 
     @JsonProperty("caseIdCollection")
     private List<CaseIdTypeItem> caseIdCollection;

--- a/src/main/java/uk/gov/hmcts/et/common/model/multiples/MultipleData.java
+++ b/src/main/java/uk/gov/hmcts/et/common/model/multiples/MultipleData.java
@@ -30,7 +30,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@EqualsAndHashCode(callSuper=false)
+@EqualsAndHashCode(callSuper = false)
 public class MultipleData extends BaseCaseData {
 
     @JsonProperty("caseIdCollection")


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###

This allows us to add properties common to single and multiple without having to copy/paste them on each type. Intended to allow methods that take in CaseData purely for the purpose of touching only referral properties to now take in BaseCaseData (soo we don't need to duplicate the methods)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
